### PR TITLE
backwards compatibility with pre 1.0 node-red

### DIFF
--- a/simple-soap.js
+++ b/simple-soap.js
@@ -81,7 +81,9 @@ module.exports = function (RED) {
                 if (err) {
                     node.error(err, msg);
                     node.status({ fill: "red", shape: "ring", text: err.code });
-                    nodeDone();
+					if(nodeDone){
+						nodeDone();
+					}
                 }
                 else {
 
@@ -110,13 +112,21 @@ module.exports = function (RED) {
                         if (parseErr) {
                             node.error(parseErr, msg);
                             node.status({ fill: "red", shape: "ring", text: parseErr });
-                            nodeDone();
+							if(nodeDone){
+								nodeDone();
+							}
                         }
                         else {
                             msg.payload = parseResult;
                             node.status({});
-                            nodeSend(msg);
-                            nodeDone();
+                            if(nodeSend){
+								nodeSend(msg);
+							} else {
+								node.send(msg);
+							}
+							if(nodeDone){
+								nodeDone();
+							}
                         }
                     });
 


### PR DESCRIPTION
Hey,

Thanks a lot of the useful node!
I tried to use it on an older version of node-red and it wouldn't work properly because you use the new signature for input. 
This PR just adds alternate behaviour around nodeDone and nodeSend to make it backwards compatible.

Thanks! 